### PR TITLE
Add the unitAmount field to Order.java, which is usually used to calculate the profit and loss situation in the contract transaction

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -32,6 +32,8 @@ public abstract class Order implements Serializable {
   private BigDecimal fee;
   /** The leverage to use for margin related to this order */
   private String leverage = null;
+  /** In some futures trading scenario, the originalAmount parameter represents the number of contracts, and the unitAmount parameter represents the par value of each contract. */
+  private BigDecimal unitAmount;
 
   /**
    * @param type Either BID (buying) or ASK (selling)
@@ -197,6 +199,14 @@ public abstract class Order implements Serializable {
 
   public void setLeverage(String leverage) {
     this.leverage = leverage;
+  }
+
+  public BigDecimal getUnitAmount() {
+    return unitAmount;
+  }
+
+  public void setUnitAmount(BigDecimal unitAmount) {
+    this.unitAmount = unitAmount;
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
@@ -268,6 +268,7 @@ public final class OkCoinAdapters {
         adaptOrderStatus(order.getStatus()));
 
     limitOrder.setLeverage(String.valueOf(order.getLeverRate()));
+    limitOrder.setUnitAmount(order.getUnitAmount());
 
     return limitOrder;
   }


### PR DESCRIPTION
In some futures trading scenario, the originalAmount parameter represents the number of contracts, and the unitAmount parameter represents the par value of each contract, so that the transaction cost and profitability can be calculated through the originalAmount parameter and the unitAmount parameter.

For an example, See the OkCoin documentation and search for "unit_amount": https://github.com/okcoin-okex/API-docs-OKEx.com/blob/master/API-For-Futures-EN/REST%20API%20for%20FUTURES.md
